### PR TITLE
Add channel name to NotificationFailed event

### DIFF
--- a/src/PusherChannel.php
+++ b/src/PusherChannel.php
@@ -49,7 +49,7 @@ class PusherChannel
 
         if (! in_array($response['status'], [200, 202])) {
             $this->events->fire(
-                new NotificationFailed($notifiable, $notification, $response)
+                new NotificationFailed($notifiable, $notification, 'pusher-push-notifications', $response)
             );
         }
     }


### PR DESCRIPTION
Had to look up the source of NotificationFailed and saw that the third parameter should be the name of the channel (https://github.com/laravel/framework/blob/master/src/Illuminate/Notifications/Events/NotificationFailed.php#L40).