### PR TITLE
Update to Mockery 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "pusher/pusher-php-server": "2.6.*"
     },
     "require-dev": {
-        "mockery/mockery": "^0.9.5",
+        "mockery/mockery": "^1.0",
         "phpunit/phpunit": "4.*"
     },
     "autoload": {


### PR DESCRIPTION
Updated `mockery/mockery` to [`^1.0`](https://github.com/mockery/mockery/releases/tag/1.0).

PS: I won't apply [this](https://styleci.io/analyses/zYgVPK) StyleCI changes. There are not related to this PR :sweat_smile: 