### PR TITLE
chore: support newer laravel

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,3 +1,1 @@
 preset: laravel
-
-linting: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
-  - 7.1
+  - 7.2
+  - 7.3
 
 env:
   matrix:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pusher push notifications channel for Laravel 5.3
+# Pusher push notifications channel for Laravel 5.5+ & 6.0
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/laravel-notification-channels/pusher-push-notifications.svg?style=flat-square)](https://packagist.org/packages/laravel-notification-channels/pusher-push-notifications)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
@@ -9,7 +9,7 @@
 [![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/laravel-notification-channels/pusher-push-notifications/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/laravel-notification-channels/pusher-push-notifications/?branch=master)
 [![Total Downloads](https://img.shields.io/packagist/dt/laravel-notification-channels/pusher-push-notifications.svg?style=flat-square)](https://packagist.org/packages/laravel-notification-channels/pusher-push-notifications)
 
-This package makes it easy to send [Pusher push notifications](https://pusher.com/docs/push_notifications) with Laravel 5.3.
+This package makes it easy to send [Pusher push notifications](https://pusher.com/docs/push_notifications) with Laravel.
 
 ## Contents
 

--- a/composer.json
+++ b/composer.json
@@ -32,16 +32,16 @@
         }
     ],
     "require": {
-        "php": ">=5.6.4",
-        "illuminate/events": "5.3.* || 5.4.* || 5.5.* || 5.6.*",
-        "illuminate/notifications": "5.3.* || 5.4.* || 5.5.* || 5.6.*",
-        "illuminate/queue": "5.3.* || 5.4.* || 5.5.* || 5.6.*",
-        "illuminate/support": "5.3.* || 5.4.* || 5.5.* || 5.6.*",
-        "pusher/pusher-php-server": "2.6.*"
+        "php": ">=7.0",
+        "illuminate/events": "~5.5 || ~6.0",
+        "illuminate/notifications": "~5.5 || ~6.0",
+        "illuminate/queue": "~5.5 || ~6.0",
+        "illuminate/support": "~5.5 || ~6.0",
+        "pusher/pusher-php-server": "~3.0 || ~4.0"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",
-        "phpunit/phpunit": "4.*"
+        "phpunit/phpunit": "5.*"
     },
     "autoload": {
         "psr-4": {

--- a/src/PusherChannel.php
+++ b/src/PusherChannel.php
@@ -2,7 +2,7 @@
 
 namespace NotificationChannels\PusherPushNotifications;
 
-use Pusher;
+use Pusher\Pusher;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Events\NotificationFailed;
@@ -10,7 +10,7 @@ use Illuminate\Notifications\Events\NotificationFailed;
 class PusherChannel
 {
     /**
-     * @var \Pusher
+     * @var Pusher
      */
     protected $pusher;
 
@@ -20,7 +20,7 @@ class PusherChannel
     private $events;
 
     /**
-     * @param \Pusher $pusher
+     * @param Pusher $pusher
      */
     public function __construct(Pusher $pusher, Dispatcher $events)
     {
@@ -42,7 +42,7 @@ class PusherChannel
             ?: $this->interestName($notifiable);
 
         $response = $this->pusher->notify(
-            $interest,
+            is_array($interest) ? $interest : [$interest],
             $notification->toPushNotification($notifiable)->toArray(),
             true
         );

--- a/src/PusherPushNotificationsServiceProvider.php
+++ b/src/PusherPushNotificationsServiceProvider.php
@@ -2,8 +2,8 @@
 
 namespace NotificationChannels\PusherPushNotifications;
 
+use Pusher\Pusher;
 use Illuminate\Support\ServiceProvider;
-use Pusher;
 
 class PusherPushNotificationsServiceProvider extends ServiceProvider
 {

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -2,15 +2,15 @@
 
 namespace NotificationChannels\PusherPushNotifications\Test;
 
-use Illuminate\Events\Dispatcher;
-use Illuminate\Notifications\Events\NotificationFailed;
-use Illuminate\Notifications\Notifiable;
-use NotificationChannels\PusherPushNotifications\PusherChannel;
-use Illuminate\Notifications\Notification;
-use NotificationChannels\PusherPushNotifications\PusherMessage;
-use PHPUnit_Framework_TestCase;
 use Mockery;
-use Pusher;
+use Pusher\Pusher;
+use PHPUnit_Framework_TestCase;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Notifications\Notifiable;
+use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\Events\NotificationFailed;
+use NotificationChannels\PusherPushNotifications\PusherChannel;
+use NotificationChannels\PusherPushNotifications\PusherMessage;
 
 class ChannelTest extends PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
- bump min PHP to 7.0
- bump min laravel to 5.5
- support 5.5+ & 6.0
- bump pusher-php-server and allow 3.x or 4.x
    - fix breaking change (namespaces)
- update readme