### PR TITLE
Correct for Laravel 5.8 deprecation

### DIFF
--- a/src/PusherChannel.php
+++ b/src/PusherChannel.php
@@ -48,7 +48,7 @@ class PusherChannel
         );
 
         if (! in_array($response['status'], [200, 202])) {
-            $this->events->fire(
+            $this->events->dispatch(
                 new NotificationFailed($notifiable, $notification, 'pusher-push-notifications', $response)
             );
         }

--- a/src/PusherChannel.php
+++ b/src/PusherChannel.php
@@ -2,10 +2,10 @@
 
 namespace NotificationChannels\PusherPushNotifications;
 
-use Pusher\Pusher;
 use Illuminate\Events\Dispatcher;
-use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Events\NotificationFailed;
+use Illuminate\Notifications\Notification;
+use Pusher\Pusher;
 
 class PusherChannel
 {


### PR DESCRIPTION
Use dispatch() instead of deprecated fire() method.

Resolves #38 