### PR TITLE
inject event contract rather concrete implementation

### DIFF
--- a/src/PusherChannel.php
+++ b/src/PusherChannel.php
@@ -2,7 +2,7 @@
 
 namespace NotificationChannels\PusherPushNotifications;
 
-use Illuminate\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Notifications\Events\NotificationFailed;
 use Illuminate\Notifications\Notification;
 use Pusher\PushNotifications\PushNotifications;
@@ -16,7 +16,7 @@ class PusherChannel
     protected $beamsClient;
 
     /**
-     * @var \Illuminate\Events\Dispatcher
+     * @var \Illuminate\Contracts\Events\Dispatcher
      */
     private $events;
 


### PR DESCRIPTION
Switching to the event dispatcher contract rather than the concrete implementation.

Depending on the concrete dispatcher was breaking tests in my Laravel app.