### PR TITLE
Publishing to users

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,21 @@ Also please note that prior to version 2.0, this package integrated with Pusher'
 
 ## Contents
 
-- [Installation](#installation)
-	- [Setting up your Pusher account](#setting-up-your-pusher-account)
-- [Usage](#usage)
-	- [Available Message methods](#available-message-methods)
-- [Changelog](#changelog)
-- [Testing](#testing)
-- [Security](#security)
-- [Contributing](#contributing)
-- [Credits](#credits)
-- [License](#license)
+- [Pusher Beams push notifications channel for Laravel 5.5+, 6.x, 7.x & 8.x](#pusher-beams-push-notifications-channel-for-laravel-55-6x-7x--8x)
+  - [Contents](#contents)
+  - [Installation](#installation)
+    - [Setting up your Pusher account](#setting-up-your-pusher-account)
+  - [Usage](#usage)
+    - [Available Message methods](#available-message-methods)
+    - [Sending to multiple platforms](#sending-to-multiple-platforms)
+    - [Routing a message](#routing-a-message)
+    - [Publish to users](#publish-to-users)
+  - [Changelog](#changelog)
+  - [Testing](#testing)
+  - [Security](#security)
+  - [Contributing](#contributing)
+  - [Credits](#credits)
+  - [License](#license)
 
 
 ## Installation
@@ -124,7 +129,7 @@ public function toPushNotification($notifiable)
 
 ### Routing a message
 
-By default, the pusher "interest" messages will be sent to will be defined using the {notifiable}.{id} convention, for example `App.User.1`, 
+By default, the pusher "interest" messages will be sent to will be defined using the {notifiable}.{id} convention, for example `App.User.1`,
 however you can change this behaviour by including a `routeNotificationFor()` in the notifiable class.
 
 I.e. if you are pushing notification on ``User`` model, you can go to `App\User` class and implement method:
@@ -141,10 +146,21 @@ public function routeNotificationFor($channel)
     return $class.'.'.$this->getKey();
 }
 ```
-     
-     
-     PusherPushNotifications()` in the notifiable class method that 
-returns the interest name.
+
+`PusherPushNotifications()` in the notifiable class method returns the interest name.
+
+### Publish to users
+
+You can publish to users in the same way that you publish to interests but you must add the following variable to the notifiable model:
+
+```
+class Client extends Model
+{
+    use Notifiable;
+
+    public $pushNotificationType = 'users';
+}
+```
 
 ## Changelog
 

--- a/src/PusherChannel.php
+++ b/src/PusherChannel.php
@@ -2,12 +2,13 @@
 
 namespace NotificationChannels\PusherPushNotifications;
 
-use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Notifications\Events\NotificationFailed;
-use Illuminate\Notifications\Notification;
-use Illuminate\Support\Arr;
-use Pusher\PushNotifications\PushNotifications;
 use Throwable;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Illuminate\Notifications\Notification;
+use Illuminate\Contracts\Events\Dispatcher;
+use Pusher\PushNotifications\PushNotifications;
+use Illuminate\Notifications\Events\NotificationFailed;
 
 class PusherChannel
 {
@@ -47,7 +48,7 @@ class PusherChannel
             ?: $this->defaultName($notifiable);
 
         try {
-            $this->beamsClient->{'publishTo'.ucfirst($type)}(
+            $this->beamsClient->{'publishTo' . Str::ucfirst($type)}(
                 Arr::wrap($data),
                 $notification->toPushNotification($notifiable)->toArray()
             );

--- a/src/PusherChannel.php
+++ b/src/PusherChannel.php
@@ -12,7 +12,9 @@ use Throwable;
 
 class PusherChannel
 {
-    /** @var string */
+    /**
+     * @var string
+     */
     const INTERESTS = 'interests';
     
     /**

--- a/src/PusherChannel.php
+++ b/src/PusherChannel.php
@@ -41,12 +41,14 @@ class PusherChannel
      */
     public function send($notifiable, Notification $notification)
     {
-        $interest = $notifiable->routeNotificationFor('PusherPushNotifications')
-            ?: $this->interestName($notifiable);
+        $type = $notifiable->pushNotificationType ?? 'interests';
+
+        $data = $notifiable->routeNotificationFor('PusherPushNotifications')
+            ?: $this->defaultName($notifiable);
 
         try {
-            $this->beamsClient->publishToInterests(
-                Arr::wrap($interest),
+            $this->beamsClient->{'publishTo'.ucfirst($type)}(
+                Arr::wrap($data),
                 $notification->toPushNotification($notifiable)->toArray()
             );
         } catch (Throwable $exception) {
@@ -57,13 +59,13 @@ class PusherChannel
     }
 
     /**
-     * Get the interest name for the notifiable.
+     * Get the default name for the notifiable.
      *
      * @param $notifiable
      *
      * @return string
      */
-    protected function interestName($notifiable)
+    protected function defaultName($notifiable)
     {
         $class = str_replace('\\', '.', get_class($notifiable));
 

--- a/src/PusherChannel.php
+++ b/src/PusherChannel.php
@@ -2,13 +2,13 @@
 
 namespace NotificationChannels\PusherPushNotifications;
 
-use Throwable;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Notifications\Events\NotificationFailed;
+use Illuminate\Notifications\Notification;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Illuminate\Notifications\Notification;
-use Illuminate\Contracts\Events\Dispatcher;
 use Pusher\PushNotifications\PushNotifications;
-use Illuminate\Notifications\Events\NotificationFailed;
+use Throwable;
 
 class PusherChannel
 {
@@ -48,7 +48,7 @@ class PusherChannel
             ?: $this->defaultName($notifiable);
 
         try {
-            $this->beamsClient->{'publishTo' . Str::ucfirst($type)}(
+            $this->beamsClient->{'publishTo'.Str::ucfirst($type)}(
                 Arr::wrap($data),
                 $notification->toPushNotification($notifiable)->toArray()
             );

--- a/src/PusherChannel.php
+++ b/src/PusherChannel.php
@@ -12,6 +12,7 @@ use Throwable;
 
 class PusherChannel
 {
+    /** @var string */
     const INTERESTS = 'interests';
     
     /**

--- a/src/PusherChannel.php
+++ b/src/PusherChannel.php
@@ -12,6 +12,8 @@ use Throwable;
 
 class PusherChannel
 {
+    const INTERESTS = 'interests';
+    
     /**
      * @var PushNotifications
      */
@@ -42,13 +44,15 @@ class PusherChannel
      */
     public function send($notifiable, Notification $notification)
     {
-        $type = $notifiable->pushNotificationType ?? 'interests';
+        $type = $notifiable->pushNotificationType ?? self::INTERESTS;
 
         $data = $notifiable->routeNotificationFor('PusherPushNotifications')
             ?: $this->defaultName($notifiable);
 
         try {
-            $this->beamsClient->{'publishTo'.Str::ucfirst($type)}(
+            $notificationType = sprintf('publishTo%s', Str::ucfirst($type));
+
+            $this->beamsClient->{$notificationType}(
                 Arr::wrap($data),
                 $notification->toPushNotification($notifiable)->toArray()
             );

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -25,25 +25,29 @@ class ChannelTest extends MockeryTestCase
 
         $this->notification = new TestNotification;
 
-        $this->notifiable = new TestNotifiable;
+        $this->notifiableInterest = new TestNotifiableInterest;
+        $this->notifiableInterests = new TestNotifiableInterests;
+
+        $this->notifiableUser = new TestNotifiableUser;
+        $this->notifiableUsers = new TestNotifiableUsers;
     }
 
     /** @test */
-    public function it_can_send_a_notification()
+    public function it_can_send_a_notification_to_interest()
     {
-        $message = $this->notification->toPushNotification($this->notifiable);
+        $message = $this->notification->toPushNotification($this->notifiableInterest);
 
         $data = $message->toArray();
 
         $this->pusher->shouldReceive('publishToInterests')->once()->with(['interest_name'], $data);
 
-        $this->channel->send($this->notifiable, $this->notification);
+        $this->channel->send($this->notifiableInterest, $this->notification);
     }
 
     /** @test */
     public function it_fires_failure_event_on_failure()
     {
-        $message = $this->notification->toPushNotification($this->notifiable);
+        $message = $this->notification->toPushNotification($this->notifiableInterest);
 
         $data = $message->toArray();
 
@@ -51,17 +55,75 @@ class ChannelTest extends MockeryTestCase
 
         $this->events->shouldReceive('dispatch')->once()->with(Mockery::type(NotificationFailed::class));
 
-        $this->channel->send($this->notifiable, $this->notification);
+        $this->channel->send($this->notifiableInterest, $this->notification);
+    }
+
+    /** @test */
+    public function it_can_send_a_notification_to_interests()
+    {
+        $message = $this->notification->toPushNotification($this->notifiableInterests);
+
+        $data = $message->toArray();
+
+        $this->pusher->shouldReceive('publishToInterests')->once()->with(['interest_one', 'interest_two', 'interest_three'], $data);
+
+        $this->channel->send($this->notifiableInterests, $this->notification);
+    }
+
+    /** @test */
+    public function it_can_send_a_notification_to_user()
+    {
+        $message = $this->notification->toPushNotification($this->notifiableUser);
+
+        $data = $message->toArray();
+
+        $this->pusher->shouldReceive('publishToUsers')->once()->with(['user_1'], $data);
+
+        $this->channel->send($this->notifiableUser, $this->notification);
     }
 }
 
-class TestNotifiable
+class TestNotifiableInterest
 {
     use Notifiable;
 
     public function routeNotificationForPusherPushNotifications()
     {
         return 'interest_name';
+    }
+}
+
+class TestNotifiableInterests
+{
+    use Notifiable;
+
+    public function routeNotificationForPusherPushNotifications()
+    {
+        return ['interest_one', 'interest_two', 'interest_three'];
+    }
+}
+
+class TestNotifiableUser
+{
+    use Notifiable;
+
+    public $pushNotificationType = 'users';
+
+    public function routeNotificationForPusherPushNotifications()
+    {
+        return 'user_1';
+    }
+}
+
+class TestNotifiableUsers
+{
+    use Notifiable;
+
+    public $pushNotificationType = 'users';
+
+    public function routeNotificationForPusherPushNotifications()
+    {
+        return ['user_1', 'user_2'];
     }
 }
 

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -45,7 +45,21 @@ class ChannelTest extends MockeryTestCase
     }
 
     /** @test */
-    public function it_fires_failure_event_on_failure()
+    public function it_can_send_a_notification_to_interests()
+    {
+        $message = $this->notification->toPushNotification($this->notifiableInterests);
+
+        $data = $message->toArray();
+
+        $this->pusher->shouldReceive('publishToInterests')->once()->with([
+            'interest_one', 'interest_two', 'interest_three',
+        ], $data);
+
+        $this->channel->send($this->notifiableInterests, $this->notification);
+    }
+
+    /** @test */
+    public function it_fires_failure_event_on_interest_failure()
     {
         $message = $this->notification->toPushNotification($this->notifiableInterest);
 
@@ -59,18 +73,6 @@ class ChannelTest extends MockeryTestCase
     }
 
     /** @test */
-    public function it_can_send_a_notification_to_interests()
-    {
-        $message = $this->notification->toPushNotification($this->notifiableInterests);
-
-        $data = $message->toArray();
-
-        $this->pusher->shouldReceive('publishToInterests')->once()->with(['interest_one', 'interest_two', 'interest_three'], $data);
-
-        $this->channel->send($this->notifiableInterests, $this->notification);
-    }
-
-    /** @test */
     public function it_can_send_a_notification_to_user()
     {
         $message = $this->notification->toPushNotification($this->notifiableUser);
@@ -78,6 +80,34 @@ class ChannelTest extends MockeryTestCase
         $data = $message->toArray();
 
         $this->pusher->shouldReceive('publishToUsers')->once()->with(['user_1'], $data);
+
+        $this->channel->send($this->notifiableUser, $this->notification);
+    }
+
+    /** @test */
+    public function it_can_send_a_notification_to_users()
+    {
+        $message = $this->notification->toPushNotification($this->notifiableUsers);
+
+        $data = $message->toArray();
+
+        $this->pusher->shouldReceive('publishToUsers')->once()->with([
+            'user_1', 'user_2', 'user_3',
+        ], $data);
+
+        $this->channel->send($this->notifiableUsers, $this->notification);
+    }
+
+    /** @test */
+    public function it_fires_failure_event_on_user_failure()
+    {
+        $message = $this->notification->toPushNotification($this->notifiableUser);
+
+        $data = $message->toArray();
+
+        $this->pusher->shouldReceive('publishToUsers')->once()->with(['user_1'], $data)->andThrow(new Exception('Something happened'));
+
+        $this->events->shouldReceive('dispatch')->once()->with(Mockery::type(NotificationFailed::class));
 
         $this->channel->send($this->notifiableUser, $this->notification);
     }
@@ -123,7 +153,7 @@ class TestNotifiableUsers
 
     public function routeNotificationForPusherPushNotifications()
     {
-        return ['user_1', 'user_2'];
+        return ['user_1', 'user_2', 'user_3'];
     }
 }
 


### PR DESCRIPTION
Hey! 👋 

This is related to issue #51, I thought I'd have a go at mocking up what the functionality could be look whilst also being backwards compatible. The `publishToInterests` functionality works as it did before (no changes required).

I guess `$beamsClient->deleteUser($userId)` and `$beamsClient->generateToken($userId)` functionalities would require you to consume another instance of the client.

Any feedback/pointers would be greatly appreciated.