### PR TITLE
Include exception into the NotificationFailed event

### DIFF
--- a/src/PusherChannel.php
+++ b/src/PusherChannel.php
@@ -61,7 +61,7 @@ class PusherChannel
             );
         } catch (Throwable $exception) {
             $this->events->dispatch(
-                new NotificationFailed($notifiable, $notification, 'pusher-push-notifications')
+                new NotificationFailed($notifiable, $notification, 'pusher-push-notifications', ['exception' => $exception])
             );
         }
     }


### PR DESCRIPTION
I was trying to gracefully process pusher errors in my project and figured out that currently it's impossible to get the actual error message. Because the `NotificationFailed` event object doesn't include any details of the error occurred.

In this PR I'm fixing that.

I don't know if I must write any additional tests because the existing tests seems to cover this case already.