### PR TITLE
Ability to add subtitle for iOS push notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ class AccountApproved extends Notification
 - `web()`: Sets the platform value to web.
 - `link()`: Accepts a string value which will lead to URI specified on notification click.
 - `title('')`: Accepts a string value for the title.
+- `subtitle('')`: Accepts a string value for the subtitle (iOS).
 - `body('')`: Accepts a string value for the body.
 - `sound('')`: Accepts a string value for the notification sound file. Notice that if you leave blank the default sound value will be `default`.
 - `icon('')`: Accepts a string value for the icon file. (Android Only)

--- a/src/PusherMessage.php
+++ b/src/PusherMessage.php
@@ -18,6 +18,11 @@ class PusherMessage
     protected string|null $title = null;
 
     /**
+     * The message subtitle.
+     */
+    protected string|null $subtitle = null;
+
+    /**
      * The phone number the message should be sent from.
      */
     protected string $sound = 'default';
@@ -196,6 +201,19 @@ class PusherMessage
     }
 
     /**
+     * Set the message subtitle.
+     *
+     * @param  string  $value
+     * @return $this
+     */
+    public function subtitle(string $value): self
+    {
+        $this->subtitle = $value;
+
+        return $this;
+    }
+
+    /**
      * Set the message body.
      *
      * @param  string  $value
@@ -305,6 +323,10 @@ class PusherMessage
                 ],
             ],
         ];
+
+        if ($this->subtitle) {
+            $message['apns']['aps']['alert']['subtitle'] = $this->subtitle;
+        }
 
         $this->formatMessage($message);
 

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -73,6 +73,14 @@ class MessageTest extends MockeryTestCase
     }
 
     /** @test */
+    public function it_can_set_the_subtitle(): void
+    {
+        $this->message->subtitle('mySubTitle');
+
+        $this->assertEquals('mySubTitle', Arr::get($this->message->toiOS(), 'apns.aps.alert.subtitle'));
+    }
+
+    /** @test */
     public function it_can_set_the_body(): void
     {
         $this->message->body('myBody');


### PR DESCRIPTION
iOS allows passing subtitles for remote push notifications https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification

Attached is a new key in `PusherMessage` for easily configuring subtitles for iOS.